### PR TITLE
Add make update-catalog and refresh targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ All Make targets run inside the `ghcr.io/appscode/golang-dev` Docker image — D
 - `make gen-values-schema` — regenerate `values.openapiv3_schema.yaml` from the Go types in `apis/installer/v1alpha1`.
 - `make gen-chart-doc` — regenerate per-chart `README.md` (one target per chart subdir under `charts/`).
 - `make update-charts` — refresh chart-level metadata (one target per chart subdir).
+- `make update-catalog` — install image-packer and regenerate `catalog/` from `imagelist.yaml`.
+- `make refresh` — `gen update-catalog fmt`. **ALWAYS run this before opening a PR** so generated files are current.
 - `make fmt` — gofmt + goimports across `apis client hack/gencrd`.
 - `make lint` — golangci-lint.
 - `make unit-tests` / `make test` — Go unit tests.
@@ -40,7 +42,7 @@ All Make targets run inside the `ghcr.io/appscode/golang-dev` Docker image — D
 
 Auxiliary helpers (invoked outside Make):
 
-- `./hack/scripts/update-catalog.sh` — regenerate `catalog/` from `imagelist.yaml` via image-packer.
+- `./hack/scripts/update-catalog.sh` — regenerate `catalog/` from `imagelist.yaml` via image-packer (wrapped by `make update-catalog`).
 - `./hack/scripts/import-crds.sh` — pull CRDs from dependent repos into the chart `crds/` dirs.
 - `./hack/scripts/update-chart-dependencies.sh` — refresh `Chart.lock` / subchart pins.
 

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,24 @@ manifests: gen-crds gen-values-schema gen-chart-doc
 .PHONY: gen
 gen: clientset manifests
 
+BIN_DIR ?= $(CURDIR)/bin/$(OS)_$(ARCH)
+
+.PHONY: install-image-packer
+install-image-packer:
+	@mkdir -p $(BIN_DIR)
+	curl -fsSL -o $(BIN_DIR)/image-packer.tar.gz https://github.com/kmodules/image-packer/releases/latest/download/image-packer-$(OS)-$(ARCH).tar.gz
+	tar -xzf $(BIN_DIR)/image-packer.tar.gz -C $(BIN_DIR)
+	chmod +x $(BIN_DIR)/image-packer-$(OS)-$(ARCH)
+	mv $(BIN_DIR)/image-packer-$(OS)-$(ARCH) $(BIN_DIR)/image-packer
+	rm -f $(BIN_DIR)/image-packer.tar.gz
+
+.PHONY: update-catalog
+update-catalog: install-image-packer
+	PATH="$(BIN_DIR):$$PATH" ./hack/scripts/update-catalog.sh
+
+.PHONY: refresh
+refresh: gen update-catalog fmt
+
 CHART_REGISTRY     ?= appscode
 CHART_REGISTRY_URL ?= https://charts.appscode.com/stable/
 CHART_VERSION      ?=


### PR DESCRIPTION
Adds catalog image-list regeneration and a one-shot refresh to the Makefile:

- `install-image-packer` — download the `image-packer` binary into `$(BIN_DIR)`.
- `update-catalog` — install image-packer and run `hack/scripts/update-catalog.sh` to regenerate `catalog/` from `imagelist.yaml`.
- `refresh` — chains `gen`, `update-catalog`, and `fmt`.

AGENTS.md documents the new targets and states that `make refresh` should always be run before opening a PR so generated files stay current.

```makefile
.PHONY: refresh
refresh: gen update-catalog fmt
```